### PR TITLE
Fix Commit new Chart.yaml step of build pipeline

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -184,8 +184,11 @@ jobs:
           git status
           git config user.name "$GITHUB_ACTOR"
           git config user.email "$GITHUB_ACTOR@users.noreply.github.com"
-          git checkout main
           git add ${CHART_PATH}/Chart.yaml
+          git stash -m "Stash uncommitted changes" -- ${CHART_PATH}/Chart.yaml
+          git fetch
+          git checkout main
+          git stash pop
           git commit -m "[Release] Update Chart.yaml"
           git push
 


### PR DESCRIPTION
On release the 'Commit new Chart.yaml' fails with the error
`error: pathspec 'main' did not match any file(s) known to git`

This change will stash the changes in the file, do a fetch
and then pop the changes.