### PR TITLE
Add linter annotations

### DIFF
--- a/charts/gpu-metrics-exporter/templates/daemonset.yaml
+++ b/charts/gpu-metrics-exporter/templates/daemonset.yaml
@@ -7,7 +7,7 @@ metadata:
     {{- include "gpu-metrics-exporter.labels" . | nindent 4 }}
   annotations:
     {{- if .Values.dcgmExporter.enabled }}
-    ignore-check.kube-linter.io/privileged-container: "This daemon set needs to run DCGM Exporter as privileged to access the GPU metrics.."
+    ignore-check.kube-linter.io/privileged-container: "This daemon set needs to run DCGM Exporter as privileged to access the GPU metrics."
     ignore-check.kube-linter.io/run-as-non-root: "This daemon set needs to run DCGM Exporter as root to access the GPU metrics."
     ignore-check.kube-linter.io/privilege-escalation-container: "This daemon set needs escalate privileges for DCGM Exporter to access the GPU metrics."
     {{-end }}

--- a/charts/gpu-metrics-exporter/templates/daemonset.yaml
+++ b/charts/gpu-metrics-exporter/templates/daemonset.yaml
@@ -5,6 +5,12 @@ metadata:
   namespace: {{ .Release.Namespace }}
   labels:
     {{- include "gpu-metrics-exporter.labels" . | nindent 4 }}
+  annotations:
+    {{- if .Values.dcgmExporter.enabled }}
+    ignore-check.kube-linter.io/privileged-container: "This daemon set needs to run DCGM Exporter as privileged to access the GPU metrics.."
+    ignore-check.kube-linter.io/run-as-non-root: "This daemon set needs to run DCGM Exporter as root to access the GPU metrics."
+    ignore-check.kube-linter.io/privilege-escalation-container: "This daemon set needs escalate privileges for DCGM Exporter to access the GPU metrics."
+    {{-end }}
 spec:
   selector:
     matchLabels:

--- a/kube-linter-config.yaml
+++ b/kube-linter-config.yaml
@@ -2,4 +2,6 @@ checks:
   exclude:
     - "unset-cpu-requirements"
     - "unset-memory-requirements"
+    - "privileged-container"
+    - "run-as-non-root"
     - "privilege-escalation-container"

--- a/kube-linter-config.yaml
+++ b/kube-linter-config.yaml
@@ -2,6 +2,4 @@ checks:
   exclude:
     - "unset-cpu-requirements"
     - "unset-memory-requirements"
-    - "privileged-container"
-    - "run-as-non-root"
-    - "privilege-escalation-container"
+

--- a/kube-linter-config.yaml
+++ b/kube-linter-config.yaml
@@ -2,4 +2,4 @@ checks:
   exclude:
     - "unset-cpu-requirements"
     - "unset-memory-requirements"
-
+    - "privilege-escalation-container"

--- a/kube-linter-config.yaml
+++ b/kube-linter-config.yaml
@@ -2,6 +2,3 @@ checks:
   exclude:
     - "unset-cpu-requirements"
     - "unset-memory-requirements"
-    - "privileged-container"
-    - "run-as-non-root"
-    - "privilege-escalation-container"


### PR DESCRIPTION
In order to not have the gpu-metrics-exporter chart completely 
ignored in in lint checks over at the castai/helm-charts repo
we add annotations to our daemon set to tell the linter when to ignore
those checks