### PR TITLE
dcgm-exporter can use existing nv-hostengine

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,9 +5,15 @@ A tool to collect GPU metrics [from DCGM Exporter](https://github.com/NVIDIA/dcg
 ## How it works
 
 The exporter can run as a sidecar to the DCGM DaemonSet, or as a single instance service in the cluster.
-When it runs as a sidecar, the `DCGM_HOST` should be set. In this case it will only scrape metrics from that particular instance of DCGM and send them to cast.ai
+When it runs as a sidecar, the `DCGM_HOST` should be set. In this case it will only scrape metrics from that particular 
+instance of DCGM and send them to cast.ai
 
-If it is deployed as a single instance in the cluster, it will automatically discover the `DCGM` instances and scrape the metrics from them. If the `DCGM` instances have some custom labels, make sure to properly set the `DCGM_LABELS` environment variable.
+If it is deployed as a single instance in the cluster, it will automatically discover the `DCGM` instances and scrape 
+the metrics from them. If the `DCGM` instances have some custom labels, make sure to properly set the `DCGM_LABELS` 
+environment variable.
+
+It is also possible to deploy the DCGM exporter but have it configured to read the metrics from an existing 
+nv-hostengine.
 
 ## Scraped metrics
 
@@ -35,6 +41,8 @@ DCGM_FI_DEV_POWER_USAGE
 
 ### Helm
 
+#### Cloning this repository
+
 You can clone this repository and install the chart with the following commands:
 ```bash
 $ cd charts/gpu-metrics-exporter
@@ -44,6 +52,18 @@ Where:
 * `<deployment-name>` is a name of your choice
 * `<k8s-provider>` is the name of the k8s provider you are using (e.g. `eks`, `gke`, `aks`)
    * this sets the proper node affinity so the Daemon Set only runs on nodes with GPUs
+#### Adding the cast.ai repository
+
+You can add the cast.ai repository and install the chart with the following commands:
+
+```bash
+$ helm repo add castai https://castai.github.io/charts
+$ helm repo update
+$ helm pull castai/gpu-metrics-exporter --untar
+$ cd gpu-metrics-exporter
+$ helm install --generate-name castai/gpu-metrics-exporter -f values.yaml -f values-<k8s-provider>.yaml
+```
+#### Configuring the installation
 
 By default, it will be deployed as a sidecar to the DCGM exporter. 
 If you don't want to deploy it as a sidecar, in the values.yaml file you can:
@@ -52,4 +72,8 @@ If you don't want to deploy it as a sidecar, in the values.yaml file you can:
    the values.yaml file
    1. `DCGM_HOST` is the address of the DCGM exporter instance
    2. `DCGM_LABELS` is a comma-separated list of labels that the DCGM instances have
+3. If you want to deploy the DCGM exporter but have it configured to read the metrics from an existing nv-hostengine,
+you can:
+   1. set the `dcgmExporter.useExternalHostEngine` to true in the values.yaml file
+   2. it will try to connect to the 5555 port of the node.
 

--- a/charts/gpu-metrics-exporter/templates/daemonset.yaml
+++ b/charts/gpu-metrics-exporter/templates/daemonset.yaml
@@ -91,7 +91,11 @@ spec:
           imagePullPolicy: {{ .Values.dcgmExporter.image.pullPolicy }}
           command: [ "/bin/bash", "-c" ]
           args:
+          {{- if .Values.dcgmExporter.useExternalHostEngine }}
+            - hostname $NODE_NAME; dcgm-exporter --remote-hostengine-info $(NODE_IP) --collectors /etc/dcgm-exporter/counters.csv
+          {{- else }}
             - hostname $NODE_NAME; dcgm-exporter --collectors /etc/dcgm-exporter/counters.csv
+          {{- end }}
           ports:
             - name: metrics
               containerPort: 9400
@@ -102,6 +106,10 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: spec.nodeName
+            - name: NODE_IP
+              valueFrom:
+                fieldRef:
+                  fieldPath: status.hostIP
             - name: "DCGM_EXPORTER_KUBERNETES_GPU_ID_TYPE"
               value: "device-name"
             - name: LD_LIBRARY_PATH

--- a/charts/gpu-metrics-exporter/values.yaml
+++ b/charts/gpu-metrics-exporter/values.yaml
@@ -19,7 +19,7 @@ gpuMetricsExporter:
   image:
     repository: ghcr.io/castai/gpu-metrics-exporter/gpu-metrics-exporter
     pullPolicy: IfNotPresent
-    tag: ""
+    tag: "latest"
   config: {}
   resources:
     limits:
@@ -40,6 +40,7 @@ dcgmExporter:
     repository: nvcr.io/nvidia/k8s/dcgm-exporter
     pullPolicy: IfNotPresent
     tag: 3.3.5-3.4.1-ubuntu22.04
+  useExternalHostEngine: false
   additionalEnv: []
   securityContext:
     privileged: true


### PR DESCRIPTION
In the case when there is an existing nv-hostengine already 
running in the cluster we allow the chart to be configured 
with a single value item so dcgm-exporter can use it.