### PR TITLE
Use default service account for better util metrics

### DIFF
--- a/charts/gpu-metrics-exporter/templates/daemonset.yaml
+++ b/charts/gpu-metrics-exporter/templates/daemonset.yaml
@@ -10,6 +10,7 @@ metadata:
     ignore-check.kube-linter.io/privileged-container: "This daemon set needs to run DCGM Exporter as privileged to access the GPU metrics."
     ignore-check.kube-linter.io/run-as-non-root: "This daemon set needs to run DCGM Exporter as root to access the GPU metrics."
     ignore-check.kube-linter.io/privilege-escalation-container: "This daemon set needs escalate privileges for DCGM Exporter to access the GPU metrics."
+    ignore-check.kube-linter.io/no-read-only-root-fs: "This daemon set needs to run DCGM Exporter with read-only root filesystem to access the GPU utilization metrics."
     {{- end }}
 spec:
   selector:

--- a/charts/gpu-metrics-exporter/templates/daemonset.yaml
+++ b/charts/gpu-metrics-exporter/templates/daemonset.yaml
@@ -31,7 +31,6 @@ spec:
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-      serviceAccountName: {{ include "gpu-metrics-exporter.serviceAccountName" . }}
       securityContext:
         {{- toYaml .Values.podSecurityContext | nindent 8 }}
       volumes:
@@ -106,7 +105,7 @@ spec:
             - name: metrics
               containerPort: 9400
           securityContext:
-            {{- toYaml .Values.dcgmExporter.securityContext | nindent 12 }}
+            privileged: true
           env:
             - name: NODE_NAME
               valueFrom:

--- a/charts/gpu-metrics-exporter/values.yaml
+++ b/charts/gpu-metrics-exporter/values.yaml
@@ -42,6 +42,3 @@ dcgmExporter:
     tag: 3.3.5-3.4.1-ubuntu22.04
   useExternalHostEngine: false
   additionalEnv: []
-  securityContext:
-    privileged: true
-    readOnlyRootFilesystem: true


### PR DESCRIPTION
In order for DCGM to be able to collect
GPU utilization correctly, the default service account 
needs to be used