### PR TITLE
Fix scheduling for AKS and EKS

### DIFF
--- a/charts/gpu-metrics-exporter/templates/daemonset.yaml
+++ b/charts/gpu-metrics-exporter/templates/daemonset.yaml
@@ -53,12 +53,6 @@ spec:
       nodeSelector:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-      {{- with .Values.affinity }}
-      affinity:
-        {{- toYaml . | nindent 8 }}
-      {{- end }}
-      tolerations:
-        - operator: "Exists"
       containers:
         - name: {{ .Chart.Name }}
           securityContext:
@@ -98,9 +92,9 @@ spec:
           command: [ "/bin/bash", "-c" ]
           args:
           {{- if .Values.dcgmExporter.useExternalHostEngine }}
-            - hostname $NODE_NAME; dcgm-exporter --remote-hostengine-info $(NODE_IP) --collectors /etc/dcgm-exporter/counters.csv
+            - hostname $NODE_NAME; test ! -f /usr/local/nvidia/lib64 && top || dcgm-exporter --remote-hostengine-info $(NODE_IP) --collectors /etc/dcgm-exporter/counters.csv
           {{- else }}
-            - hostname $NODE_NAME; dcgm-exporter --collectors /etc/dcgm-exporter/counters.csv
+            - hostname $NODE_NAME; test ! -f /usr/local/nvidia/lib64 && top || dcgm-exporter --collectors /etc/dcgm-exporter/counters.csv
           {{- end }}
           ports:
             - name: metrics

--- a/charts/gpu-metrics-exporter/templates/daemonset.yaml
+++ b/charts/gpu-metrics-exporter/templates/daemonset.yaml
@@ -53,6 +53,12 @@ spec:
       nodeSelector:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+            {{- toYaml . | nindent 8 }}
+          {{- end }}
+      tolerations:
+        - operator: "Exists"
       containers:
         - name: {{ .Chart.Name }}
           securityContext:
@@ -92,9 +98,9 @@ spec:
           command: [ "/bin/bash", "-c" ]
           args:
           {{- if .Values.dcgmExporter.useExternalHostEngine }}
-            - hostname $NODE_NAME; test ! -f /usr/local/nvidia/lib64 && top || dcgm-exporter --remote-hostengine-info $(NODE_IP) --collectors /etc/dcgm-exporter/counters.csv
+            - hostname $NODE_NAME; for ((;;)) { r=$(dcgm-exporter --remote-hostengine-info $(NODE_IP) --collectors /etc/dcgm-exporter/counters.csv); echo "dcgm-exporter could not run"; sleep 30 ; }
           {{- else }}
-            - hostname $NODE_NAME; test ! -f /usr/local/nvidia/lib64 && top || dcgm-exporter --collectors /etc/dcgm-exporter/counters.csv
+            - hostname $NODE_NAME; for ((;;)) { r=$(dcgm-exporter --collectors /etc/dcgm-exporter/counters.csv); echo "dcgm-exporter could not run"; sleep 30 ; }
           {{- end }}
           ports:
             - name: metrics

--- a/charts/gpu-metrics-exporter/templates/daemonset.yaml
+++ b/charts/gpu-metrics-exporter/templates/daemonset.yaml
@@ -55,8 +55,8 @@ spec:
       {{- end }}
       {{- with .Values.affinity }}
       affinity:
-            {{- toYaml . | nindent 8 }}
-          {{- end }}
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       tolerations:
         - operator: "Exists"
       containers:

--- a/charts/gpu-metrics-exporter/values-aks.yaml
+++ b/charts/gpu-metrics-exporter/values-aks.yaml
@@ -1,7 +1,0 @@
-affinity:
-  nodeAffinity:
-    requiredDuringSchedulingIgnoredDuringExecution:
-      nodeSelectorTerms:
-        - matchExpressions:
-            - key: kubernetes.azure.com/accelerator
-              operator: Exists

--- a/charts/gpu-metrics-exporter/values-eks.yaml
+++ b/charts/gpu-metrics-exporter/values-eks.yaml
@@ -1,7 +1,0 @@
-affinity:
-  nodeAffinity:
-    requiredDuringSchedulingIgnoredDuringExecution:
-      nodeSelectorTerms:
-        - matchExpressions:
-            - key: k8s.amazonaws.com/accelerator
-              operator: Exists


### PR DESCRIPTION
The node selector based affinity rules are wrong for AKS
and EKS.

In the case where node affinity is not set up, we're modifying 
the daemon set to run on all nodes. Because dcgm-exporter 
crashes on nodes without an Nvidia driver (and no gpu attached)
we're modifying the dcgm-exporter container to run regardless 
of failures