### PR TITLE
Add service account so gpu-exporter can list pods

### DIFF
--- a/charts/gpu-metrics-exporter/templates/daemonset.yaml
+++ b/charts/gpu-metrics-exporter/templates/daemonset.yaml
@@ -57,8 +57,6 @@ spec:
       affinity:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-      tolerations:
-        - operator: "Exists"
       containers:
         - name: {{ .Chart.Name }}
           securityContext:

--- a/charts/gpu-metrics-exporter/templates/service-acc.yaml
+++ b/charts/gpu-metrics-exporter/templates/service-acc.yaml
@@ -1,0 +1,27 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: gpu-exporter-sa
+  namespace: {{ .Release.Namespace }}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: list-pods-clusterrole
+rules:
+  - apiGroups: [""]
+    resources: ["pods"]
+    verbs: ["list"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: list-pods-clusterrolebinding
+subjects:
+  - kind: ServiceAccount
+    name: gpu-exporter-sa
+    namespace: {{ .Release.Namespace }}
+roleRef:
+  kind: ClusterRole
+  name: list-pods-clusterrole
+  apiGroup: rbac.authorization.k8s.io

--- a/charts/gpu-metrics-exporter/values.yaml
+++ b/charts/gpu-metrics-exporter/values.yaml
@@ -14,7 +14,7 @@ additionalVolumes: []
 serviceAccount:
   create: true
   automount: true
-  annotations: { }
+  annotations: {}
 gpuMetricsExporter:
   image:
     repository: ghcr.io/castai/gpu-metrics-exporter/gpu-metrics-exporter


### PR DESCRIPTION
In cases where the DCGM host address is not provided gpu-metrics-exporter lists 
the pods with a specific label. The default service accounts does not have
enough permissions to list the pods. A new ServiceAccount and ClusterRole 
are created.