### PR TITLE
feat: Add wildcard tolerations to gpu-metrics-exporter

### DIFF
--- a/charts/gpu-metrics-exporter/values.yaml
+++ b/charts/gpu-metrics-exporter/values.yaml
@@ -28,9 +28,10 @@ gpuMetricsExporter:
     runAsNonRoot: true
   port: 6061
   tolerations:
-    - key: "nvidia.com/gpu"
-      value: "true"
-      effect: "NoSchedule"
+    - effect: "NoExecute"
+      operator: "Exists"
+    - effect: "NoExecute"
+      operator: "Exists"
 
 dcgmExporter:
   enabled: true


### PR DESCRIPTION
Add wildcard tolerations to gpu-metrics-exporter so that it can be scheduled to tainted nodes