### PR TITLE
Makes cluster id work without config, same with cast api url

### DIFF
--- a/charts/gpu-metrics-exporter/templates/gpu-exporter-configmap.yaml
+++ b/charts/gpu-metrics-exporter/templates/gpu-exporter-configmap.yaml
@@ -3,11 +3,21 @@ kind: ConfigMap
 metadata:
   name: {{- include "gpu-metrics-exporter.config-map" . | indent 1}}
 data:
-{{- with .Values.gpuMetricsExporter.config }}
-  CLUSTER_ID: "{{ $.Values.castai.clusterId | default .CLUSTER_ID }}"
-  {{- toYaml (omit . "CLUSTER_ID") | nindent 2 }}
+
+{{- $config := .Values.gpuMetricsExporter.config | default dict }}
+{{- $clusterID := $.Values.castai.clusterId | default ($config.CLUSTER_ID | default "") }}
+{{- $castApi := $.Values.castai.apiUrl | default ($config.CAST_API | default "") }}
+
+{{- if $clusterID }}
+  CLUSTER_ID: "{{ $clusterID }}"
 {{- end }}
-{{- $castApi := $.Values.castai.apiUrl | default .CAST_API }}
+
 {{- if $castApi }}
   CAST_API: "{{ $castApi }}"
 {{- end }}
+
+{{- $otherConfig := omit $config "CLUSTER_ID" "CAST_API"}}
+{{- if $otherConfig }}
+  {{- toYaml $otherConfig | nindent 2 }}
+{{- end }}
+

--- a/charts/gpu-metrics-exporter/templates/gpu-exporter-configmap.yaml
+++ b/charts/gpu-metrics-exporter/templates/gpu-exporter-configmap.yaml
@@ -20,4 +20,3 @@ data:
 {{- if $otherConfig }}
   {{- toYaml $otherConfig | nindent 2 }}
 {{- end }}
-


### PR DESCRIPTION
Previously if we wanted to use castai.clusterId, we would need to have at least something defined in the gpuMetricsExporter.config, this fixes that issue and applies the same logic to apiUrl