### PR TITLE
feat: support global apiURL/provider from umbrella chart and clusterIdConfigMapKeyRef

### DIFF
--- a/charts/gpu-metrics-exporter/templates/_helpers.tpl
+++ b/charts/gpu-metrics-exporter/templates/_helpers.tpl
@@ -74,3 +74,11 @@ Create the name of the gpu-metrics-exporter config map
 {{- define "gpu-metrics-exporter.config-map" -}}
 {{- printf "%s-%s" .Release.Name "gpu-metrics-exporter" | replace "+" "_" | trunc 63 | trimSuffix "-" }}
 {{- end }}
+
+{{- define "gpu-metrics-exporter.apiURL" -}}
+{{- coalesce (dig "castai" "apiURL" "" (.Values.global | default dict)) .Values.castai.apiUrl -}}
+{{- end }}
+
+{{- define "gpu-metrics-exporter.provider" -}}
+{{- coalesce (dig "castai" "provider" "" (.Values.global | default dict)) .Values.provider -}}
+{{- end }}

--- a/charts/gpu-metrics-exporter/templates/daemonset.yaml
+++ b/charts/gpu-metrics-exporter/templates/daemonset.yaml
@@ -29,7 +29,8 @@ spec:
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-      {{- if eq (required ".Values.provider is required (gke|eks|aks|omni)" .Values.provider) "eks" }}
+      {{- $provider := include "gpu-metrics-exporter.provider" . }}
+      {{- if eq (required ".Values.provider is required (gke|eks|aks|omni)" $provider) "eks" }}
       priorityClassName: system-node-critical
       {{- end }}
       serviceAccountName: {{ include "gpu-metrics-exporter.serviceAccountName" . }}
@@ -41,7 +42,7 @@ spec:
         - name: {{- include "dcgm-exporter.config-map" . | indent 1 }}
           configMap:
             name: {{- include "dcgm-exporter.config-map" . | indent 1 }}
-        {{- if eq .Values.provider "gke" }}
+        {{- if eq $provider "gke" }}
         - name: "nvidia-install-dir-host"
           hostPath:
             path: /home/kubernetes/bin/nvidia
@@ -56,7 +57,7 @@ spec:
       affinity:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-      {{- else if (eq .Values.provider "gke")}}
+      {{- else if (eq $provider "gke")}}
       {{- with .Values.gke.affinity }}
       affinity:
         {{- toYaml . | nindent 8 }}
@@ -111,6 +112,12 @@ spec:
                 secretKeyRef:
                   name: {{ .Values.castai.clusterIdSecretRef }}
                   key: CLUSTER_ID
+          {{- else if .Values.castai.clusterIdConfigMapKeyRef.name }}
+            - name: "CLUSTER_ID"
+              valueFrom:
+                configMapKeyRef:
+                  name: {{ .Values.castai.clusterIdConfigMapKeyRef.name }}
+                  key: {{ .Values.castai.clusterIdConfigMapKeyRef.key | default "CLUSTER_ID" }}
           {{- end }}
           {{- if .Values.dcgmExporter.enabled }}
             - name: "DCGM_HOST"
@@ -128,14 +135,14 @@ spec:
                 - NET_RAW
             runAsNonRoot: false
             runAsUser: 0
-            {{- if eq .Values.provider "gke"}}
+            {{- if eq $provider "gke"}}
             privileged: true
             {{- end }}
           image: "{{ .Values.dcgmExporter.image.repository }}:{{ .Values.dcgmExporter.image.tag }}"
           imagePullPolicy: {{ .Values.dcgmExporter.image.pullPolicy }}
           command: [ "/bin/bash", "-c" ]
           args:
-          {{- if eq .Values.provider "gke"}}
+          {{- if eq $provider "gke"}}
             {{- if .Values.dcgmExporter.useExternalHostEngine }}
             - hostname $NODE_NAME; dcgm-exporter --remote-hostengine-info $(NODE_IP) -f /etc/dcgm-exporter/counters.csv
             {{- else }}
@@ -162,7 +169,7 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: spec.nodeName
-            {{- if eq .Values.provider "gke" }}
+            {{- if eq $provider "gke" }}
             - name: "NODE_IP"
               valueFrom:
                 fieldRef:
@@ -176,7 +183,7 @@ spec:
             - name: "pod-gpu-resources"
               readOnly: true
               mountPath: "/var/lib/kubelet/pod-resources"
-            {{- if eq .Values.provider "gke" }}
+            {{- if eq $provider "gke" }}
             - name: "nvidia-install-dir-host"
               mountPath: /usr/local/nvidia
             {{- end }}

--- a/charts/gpu-metrics-exporter/templates/daemonset.yaml
+++ b/charts/gpu-metrics-exporter/templates/daemonset.yaml
@@ -30,7 +30,7 @@ spec:
         {{- toYaml . | nindent 8 }}
       {{- end }}
       {{- $provider := include "gpu-metrics-exporter.provider" . }}
-      {{- if eq (required ".Values.provider is required (gke|eks|aks|omni)" $provider) "eks" }}
+      {{- if eq (required "provider or global.castai.provider is required (gke|eks|aks|omni)" $provider) "eks" }}
       priorityClassName: system-node-critical
       {{- end }}
       serviceAccountName: {{ include "gpu-metrics-exporter.serviceAccountName" . }}

--- a/charts/gpu-metrics-exporter/templates/gpu-exporter-configmap.yaml
+++ b/charts/gpu-metrics-exporter/templates/gpu-exporter-configmap.yaml
@@ -3,10 +3,10 @@ kind: ConfigMap
 metadata:
   name: {{- include "gpu-metrics-exporter.config-map" . | indent 1}}
 data:
-{{- if not .Values.castai.clusterIdSecretRef }}
+{{- if and (not .Values.castai.clusterIdSecretRef) (not .Values.castai.clusterIdConfigMapKeyRef.name) }}
   CLUSTER_ID: {{ required "castai.clusterId must be provided" .Values.castai.clusterId | quote }}
 {{- end }}
-  CAST_API: {{ required "castai.apiUrl must be provided" .Values.castai.apiUrl | quote }}
+  CAST_API: {{ required "castai.apiUrl must be provided" (include "gpu-metrics-exporter.apiURL" .) | quote }}
 
 {{- $config := .Values.gpuMetricsExporter.config | default dict }}
 {{- $otherConfig := omit $config "CLUSTER_ID" "CAST_API"}}

--- a/charts/gpu-metrics-exporter/templates/gpu-exporter-configmap.yaml
+++ b/charts/gpu-metrics-exporter/templates/gpu-exporter-configmap.yaml
@@ -6,7 +6,7 @@ data:
 {{- if and (not .Values.castai.clusterIdSecretRef) (not .Values.castai.clusterIdConfigMapKeyRef.name) }}
   CLUSTER_ID: {{ required "castai.clusterId must be provided" .Values.castai.clusterId | quote }}
 {{- end }}
-  CAST_API: {{ required "castai.apiUrl must be provided" (include "gpu-metrics-exporter.apiURL" .) | quote }}
+  CAST_API: {{ required "castai.apiUrl or global.castai.apiURL must be provided" (include "gpu-metrics-exporter.apiURL" .) | quote }}
 
 {{- $config := .Values.gpuMetricsExporter.config | default dict }}
 {{- $otherConfig := omit $config "CLUSTER_ID" "CAST_API"}}

--- a/charts/gpu-metrics-exporter/templates/validation.yaml
+++ b/charts/gpu-metrics-exporter/templates/validation.yaml
@@ -2,13 +2,14 @@
 Validation for provider parameter
 */}}
 {{- $validProviders := list "gke" "eks" "aks" "omni" }}
-{{- if and .Values.provider (not (has .Values.provider $validProviders)) }}
-{{- fail (printf "Invalid provider '%s'. Must be one of: %s" .Values.provider (join " | " $validProviders)) }}
+{{- $provider := include "gpu-metrics-exporter.provider" . }}
+{{- if and $provider (not (has $provider $validProviders)) }}
+{{- fail (printf "Invalid provider '%s'. Must be one of: %s" $provider (join " | " $validProviders)) }}
 {{- end }}
 
 {{/*
 Require either clusterId or clusterIdSecretRef
 */}}
-{{- if and (not .Values.castai.clusterId) (not .Values.castai.clusterIdSecretRef) }}
-{{- fail "one of castai.clusterId or castai.clusterIdSecretRef must be set" }}
+{{- if and (not .Values.castai.clusterId) (not .Values.castai.clusterIdSecretRef) (not .Values.castai.clusterIdConfigMapKeyRef.name) }}
+{{- fail "one of castai.clusterId, castai.clusterIdSecretRef, or castai.clusterIdConfigMapKeyRef must be set" }}
 {{- end }}

--- a/charts/gpu-metrics-exporter/templates/validation.yaml
+++ b/charts/gpu-metrics-exporter/templates/validation.yaml
@@ -8,8 +8,19 @@ Validation for provider parameter
 {{- end }}
 
 {{/*
-Require either clusterId or clusterIdSecretRef
+Require one of clusterId, clusterIdSecretRef, or clusterIdConfigMapKeyRef
 */}}
 {{- if and (not .Values.castai.clusterId) (not .Values.castai.clusterIdSecretRef) (not .Values.castai.clusterIdConfigMapKeyRef.name) }}
 {{- fail "one of castai.clusterId, castai.clusterIdSecretRef, or castai.clusterIdConfigMapKeyRef must be set" }}
+{{- end }}
+
+{{/*
+Ensure mutual exclusivity of cluster ID sources
+*/}}
+{{- $clusterIdCount := 0 }}
+{{- if .Values.castai.clusterId }}{{ $clusterIdCount = add $clusterIdCount 1 }}{{ end }}
+{{- if .Values.castai.clusterIdSecretRef }}{{ $clusterIdCount = add $clusterIdCount 1 }}{{ end }}
+{{- if .Values.castai.clusterIdConfigMapKeyRef.name }}{{ $clusterIdCount = add $clusterIdCount 1 }}{{ end }}
+{{- if gt (int $clusterIdCount) 1 }}
+{{- fail "only one of castai.clusterId, castai.clusterIdSecretRef, or castai.clusterIdConfigMapKeyRef may be set" }}
 {{- end }}

--- a/charts/gpu-metrics-exporter/tests/configmap_ref_test.yaml
+++ b/charts/gpu-metrics-exporter/tests/configmap_ref_test.yaml
@@ -1,0 +1,35 @@
+suite: clusterIdConfigMapKeyRef wires CLUSTER_ID from external ConfigMap
+templates:
+  - gpu-exporter-configmap.yaml
+  - secret.yaml
+  - daemonset.yaml
+set:
+  castai.apiKeySecretRef: castai-credentials
+  castai.clusterIdConfigMapKeyRef.name: castai-agent-metadata
+  castai.clusterIdConfigMapKeyRef.key: CLUSTER_ID
+  global.castai.provider: gke
+tests:
+  - it: gpu-exporter ConfigMap omits CLUSTER_ID key
+    template: gpu-exporter-configmap.yaml
+    asserts:
+      - notExists:
+          path: data.CLUSTER_ID
+
+  - it: DaemonSet has CLUSTER_ID env var sourced from configMapKeyRef
+    template: daemonset.yaml
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: "CLUSTER_ID"
+            valueFrom:
+              configMapKeyRef:
+                name: castai-agent-metadata
+                key: CLUSTER_ID
+
+  - it: No gpu-metrics-exporter Secret contains the API key (apiKeySecretRef is used instead)
+    template: secret.yaml
+    asserts:
+      - notEqual:
+          path: data.API_KEY
+          value: "bXlrZXk="

--- a/charts/gpu-metrics-exporter/tests/configmap_ref_test.yaml
+++ b/charts/gpu-metrics-exporter/tests/configmap_ref_test.yaml
@@ -27,9 +27,8 @@ tests:
                 name: castai-agent-metadata
                 key: CLUSTER_ID
 
-  - it: No gpu-metrics-exporter Secret contains the API key (apiKeySecretRef is used instead)
+  - it: No gpu-metrics-exporter Secret is rendered (apiKeySecretRef is used instead)
     template: secret.yaml
     asserts:
-      - notEqual:
-          path: data.API_KEY
-          value: "bXlrZXk="
+      - hasDocuments:
+          count: 0

--- a/charts/gpu-metrics-exporter/tests/global_values_test.yaml
+++ b/charts/gpu-metrics-exporter/tests/global_values_test.yaml
@@ -1,0 +1,51 @@
+suite: global values take precedence over local values
+templates:
+  - gpu-exporter-configmap.yaml
+  - secret.yaml
+  - daemonset.yaml
+set:
+  global.castai.apiKey: "global-api-key"
+  global.castai.apiURL: "https://global.api.cast.ai"
+  global.castai.provider: "gke"
+  global.castai.clusterID: "global-cluster-id"
+  castai.apiKey: "local-api-key"
+  castai.apiUrl: "https://local.api.cast.ai"
+  provider: "eks"
+  castai.clusterId: "local-cluster-id"
+tests:
+  - it: ConfigMap uses global CAST_API not local
+    template: gpu-exporter-configmap.yaml
+    asserts:
+      - equal:
+          path: data.CAST_API
+          value: "https://global.api.cast.ai"
+
+  - it: ConfigMap uses local CLUSTER_ID (global.castai.clusterID is not supported)
+    template: gpu-exporter-configmap.yaml
+    asserts:
+      - equal:
+          path: data.CLUSTER_ID
+          value: "local-cluster-id"
+
+  - it: Secret uses local API key (global.castai.apiKey is not supported)
+    template: secret.yaml
+    asserts:
+      - equal:
+          path: data.API_KEY
+          value: "bG9jYWwtYXBpLWtleQ=="
+
+  - it: DaemonSet uses global provider gke so no priorityClassName
+    template: daemonset.yaml
+    asserts:
+      - notExists:
+          path: spec.template.spec.priorityClassName
+
+  - it: DaemonSet uses global provider gke so nvidia volume is present
+    template: daemonset.yaml
+    asserts:
+      - contains:
+          path: spec.template.spec.volumes
+          content:
+            name: "nvidia-install-dir-host"
+            hostPath:
+              path: /home/kubernetes/bin/nvidia

--- a/charts/gpu-metrics-exporter/tests/local_values_test.yaml
+++ b/charts/gpu-metrics-exporter/tests/local_values_test.yaml
@@ -1,0 +1,48 @@
+suite: local values work when globals are absent
+templates:
+  - gpu-exporter-configmap.yaml
+  - secret.yaml
+  - daemonset.yaml
+set:
+  castai.apiKey: "local-api-key"
+  castai.apiUrl: "https://local.api.cast.ai"
+  provider: "eks"
+  castai.clusterId: "local-cluster-id"
+tests:
+  - it: ConfigMap uses local CAST_API
+    template: gpu-exporter-configmap.yaml
+    asserts:
+      - equal:
+          path: data.CAST_API
+          value: "https://local.api.cast.ai"
+
+  - it: ConfigMap uses local CLUSTER_ID
+    template: gpu-exporter-configmap.yaml
+    asserts:
+      - equal:
+          path: data.CLUSTER_ID
+          value: "local-cluster-id"
+
+  - it: Secret uses local API key
+    template: secret.yaml
+    asserts:
+      - equal:
+          path: data.API_KEY
+          value: "bG9jYWwtYXBpLWtleQ=="
+
+  - it: DaemonSet uses local provider eks so priorityClassName is set
+    template: daemonset.yaml
+    asserts:
+      - equal:
+          path: spec.template.spec.priorityClassName
+          value: "system-node-critical"
+
+  - it: DaemonSet uses local provider eks so nvidia volume is absent
+    template: daemonset.yaml
+    asserts:
+      - notContains:
+          path: spec.template.spec.volumes
+          content:
+            name: "nvidia-install-dir-host"
+            hostPath:
+              path: /home/kubernetes/bin/nvidia

--- a/charts/gpu-metrics-exporter/tests/validation_test.yaml
+++ b/charts/gpu-metrics-exporter/tests/validation_test.yaml
@@ -1,0 +1,33 @@
+suite: mutual exclusivity of cluster ID sources
+templates:
+  - validation.yaml
+set:
+  castai.apiKey: "test-key"
+  castai.apiUrl: "https://api.cast.ai"
+  provider: "gke"
+tests:
+  - it: fails when both clusterIdSecretRef and clusterIdConfigMapKeyRef are set
+    set:
+      castai.clusterIdSecretRef: "my-secret"
+      castai.clusterIdConfigMapKeyRef.name: "my-configmap"
+      castai.clusterIdConfigMapKeyRef.key: "CLUSTER_ID"
+    asserts:
+      - failedTemplate:
+          errorMessage: "only one of castai.clusterId, castai.clusterIdSecretRef, or castai.clusterIdConfigMapKeyRef may be set"
+
+  - it: fails when both clusterId and clusterIdSecretRef are set
+    set:
+      castai.clusterId: "my-cluster"
+      castai.clusterIdSecretRef: "my-secret"
+    asserts:
+      - failedTemplate:
+          errorMessage: "only one of castai.clusterId, castai.clusterIdSecretRef, or castai.clusterIdConfigMapKeyRef may be set"
+
+  - it: fails when both clusterId and clusterIdConfigMapKeyRef are set
+    set:
+      castai.clusterId: "my-cluster"
+      castai.clusterIdConfigMapKeyRef.name: "my-configmap"
+      castai.clusterIdConfigMapKeyRef.key: "CLUSTER_ID"
+    asserts:
+      - failedTemplate:
+          errorMessage: "only one of castai.clusterId, castai.clusterIdSecretRef, or castai.clusterIdConfigMapKeyRef may be set"

--- a/charts/gpu-metrics-exporter/values.yaml
+++ b/charts/gpu-metrics-exporter/values.yaml
@@ -1,3 +1,8 @@
+global:
+  castai:
+    apiURL: ""
+    provider: ""
+
 provider: "" # gke | eks | aks | omni
 imagePullSecrets: [ ]
 
@@ -21,6 +26,13 @@ castai:
   # The referenced secret must provide the ID of the cluster in .data["CLUSTER_ID"]
   # clusterId and clusterIdSecretRef are mutually exclusive
   clusterIdSecretRef:
+
+  # Name of ConfigMap key ref for CLUSTER_ID.
+  # clusterIdConfigMapKeyRef and clusterIdSecretRef and clusterId are mutually exclusive.
+  # The referenced ConfigMap must provide the cluster ID in the specified key.
+  clusterIdConfigMapKeyRef:
+    name: ""
+    key: "CLUSTER_ID"
   
   # CASTAI public api url.
   apiUrl: "https://api.cast.ai"


### PR DESCRIPTION
## Context

The umbrella chart passes shared configuration (API URL, cloud provider) via `global.castai.*` values, and wires cluster identity via an existing ConfigMap (`castai-agent-metadata`) rather than inline values. This change makes `gpu-metrics-exporter` compatible with that pattern, similar to what was done for [kvisor](https://github.com/castai/kvisor/pull/653) and [workload-autoscaler](https://github.com/castai/workload-autoscaler/pull/377).

## Summary

- Add `global.castai.apiURL` and `global.castai.provider` to `values.yaml` so the chart picks them up when deployed as a subchart under the umbrella (via `coalesce` with local values as fallback)
- Add `castai.clusterIdConfigMapKeyRef` support — allows `CLUSTER_ID` to be sourced from an existing ConfigMap (e.g. `castai-agent-metadata`) rather than inlined as a static value, which is how the umbrella chart wires it
- Add helm-unittest test suites: `configmap_ref_test.yaml`, `global_values_test.yaml`, `local_values_test.yaml`